### PR TITLE
Update get_instance Regex

### DIFF
--- a/lib/salesforce_chunker/connection.rb
+++ b/lib/salesforce_chunker/connection.rb
@@ -57,7 +57,7 @@ module SalesforceChunker
     private
 
     def self.get_instance(server_url)
-      /[a-z0-9]+.salesforce/.match(server_url)[0].split(".")[0]
+      /https:\/\/(.*).salesforce.com/.match(server_url)[1]
     end
   end
 end

--- a/test/lib/connection_test.rb
+++ b/test/lib/connection_test.rb
@@ -45,7 +45,20 @@ class ConnectionTest < Minitest::Test
   end
 
   def test_get_instance_extracts_instance
-    assert_equal "na99", SalesforceChunker::Connection.get_instance("https://na99.salesforce.com/something")
+    urls = [
+      "https://na99.salesforce.com/something",
+      "https://a.lot.of.dots.salesforce.com/something",
+      "https://dots.and-dashes--.salesforce.com/something",
+    ]
+
+    expected_instances = [
+      "na99",
+      "a.lot.of.dots",
+      "dots.and-dashes--",
+    ]
+
+    extracted_instances = urls.map { |url| SalesforceChunker::Connection.get_instance(url) }
+    assert_equal expected_instances, extracted_instances
   end
 
   private


### PR DESCRIPTION
**What**
Replaces current regex to capture more cases such as:
 - `https://na99.my.salesforce.com` -> `na99.my`
 - `https://na-9-99.my.salesforce.com` -> `na-9-99.my`

**Why**
The previous regex pattern was not capturing server URLs that contained intermittent periods. This motivated updating the pattern to this current form.

cc @csholmes 
