### PR TITLE
Lower HTTParty Gem Version Dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     salesforce_chunker (0.1.0)
-      httparty (~> 0.16.2)
+      httparty (~> 0.13)
 
 GEM
   remote: https://rubygems.org/

--- a/salesforce_chunker.gemspec
+++ b/salesforce_chunker.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "httparty", "~> 0.16.2"
+  spec.add_dependency "httparty", "~> 0.13"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
**Why**
Some jobs in Longboat are incompatible with HTTParty `v 0.16.2`. This PR changes the gem dependency to `v 0.13.1`, which is the version that Longboat uses.

cc @csholmes 