### PR TITLE
create get_completed_batches function in job

### DIFF
--- a/lib/salesforce_chunker/job.rb
+++ b/lib/salesforce_chunker/job.rb
@@ -12,6 +12,14 @@ module SalesforceChunker
       create_batch(query)
     end
 
+    def get_completed_batches
+      get_batch_statuses.select do |batch|
+        raise BatchError, "Batch failed: #{batch["stateMessage"]}" if batch["state"] == "Failed"
+        raise RecordError, "Failed records in batch" if batch["state"] == "Completed" && batch["numberRecordsFailed"] > 0
+        batch["state"] == "Completed"
+      end
+    end
+
     def get_batch_statuses
       response = @connection.get_json("job/#{@job_id}/batch")
       batches = response["batchInfo"]


### PR DESCRIPTION
We want to simplify the big loop in `lib/salesforce_chunker.rb`.

This PR creates a `get_completed_batches` function in `SalesforceChunker::Job` that raises an error if there are any issues with batch processing, and returns a list of completed batches.

This has been manually tested, and all tests pass.