### PR TITLE
Change get batch statuses

### DIFF
--- a/test/lib/job_test.rb
+++ b/test/lib/job_test.rb
@@ -32,7 +32,23 @@ class JobTest < Minitest::Test
     assert_equal 2, @job.get_batch_statuses.size
   end
 
-  def test_get_batch_status_sets_batches_count_and_closes_once_initial_batch_is_ready
+  def test_get_batch_status_calls_finalize_chunking_setup_when_batches_count_is_nil
+    connection = mock()
+    connection.expects(:get_json).with(
+      "job/3811P00000EFQiYQAX/batch",
+    ).returns({"batchInfo" => [
+      {"id"=> "55024000002iETSAA2", "state"=> "Completed"},
+      {"id"=> "55024000002iETTAA2", "state"=> "InProgress"},
+    ]})
+    @job.instance_variable_set(:@connection, connection)
+    @job.instance_variable_set(:@job_id, "3811P00000EFQiYQAX")
+    @job.instance_variable_set(:@batches_count, nil)
+    @job.expects(:finalize_chunking_setup)
+
+    @job.get_batch_statuses
+  end
+
+  def test_get_batch_status_doesnt_call_finalize_chunking_setup_when_batches_count_is_not_nil
     connection = mock()
     connection.expects(:get_json).with(
       "job/3811P00000EFQiYQAX/batch",
@@ -44,26 +60,34 @@ class JobTest < Minitest::Test
     ]})
     @job.instance_variable_set(:@connection, connection)
     @job.instance_variable_set(:@job_id, "3811P00000EFQiYQAX")
+    @job.instance_variable_set(:@batches_count, 3)
+    @job.expects(:finalize_chunking_setup).never
+
+    @job.get_batch_statuses
+  end
+
+  def test_finalize_chunking_setup_sets_batches_count_and_closes_once_initial_batch_is_ready
+    batches = [
+      {"id"=> "55024000002iETSAA2", "state"=> "NotProcessed"},
+      {"id"=> "55024000002iETTAA2", "state"=> "InProgress"},
+      {"id"=> "55024000002iETUAA2", "state"=> "InProgress"},
+      {"id"=> "55024000002iETVAA2", "state"=> "Completed"},
+    ]
     @job.instance_variable_set(:@initial_batch_id, "55024000002iETSAA2")
     @job.expects(:close)
 
-    @job.get_batch_statuses
+    @job.send(:finalize_chunking_setup, batches)
     assert_equal 3, @job.instance_variable_get(:@batches_count)
   end
 
-  def test_get_batch_status_doesnt_set_batches_count_and_doesnt_close_before_initial_batch_is_ready
-    connection = mock()
-    connection.expects(:get_json).with(
-      "job/3811P00000EFQiYQAX/batch",
-    ).returns({"batchInfo" => [
+  def test_finalize_chunking_setup_doesnt_set_batches_count_or_close_before_initial_batch_is_ready
+    batches = [
       {"id"=> "55024000002iETSAA2", "state"=> "Queued"},
-    ]})
-    @job.instance_variable_set(:@connection, connection)
-    @job.instance_variable_set(:@job_id, "3811P00000EFQiYQAX")
+    ]
     @job.instance_variable_set(:@initial_batch_id, "55024000002iETSAA2")
     @job.expects(:close).never
 
-    @job.get_batch_statuses
+    @job.send(:finalize_chunking_setup, batches)
     assert_nil @job.instance_variable_get(:@batches_count)
   end
 


### PR DESCRIPTION
Pulls `finalize_chunking_setup` out of `get_batch_statuses` and into it's own function, with it's own tests.

Eventually, we want to separate `SalesforceChunker::Job` and `SalesforceChunker::PKChunkingJob`, and `finalize_chunking_setup` really is only a concern for PK Chunking and not other uses for `Job`.