### PR TITLE
Rearrange job

### DIFF
--- a/lib/salesforce_chunker/job.rb
+++ b/lib/salesforce_chunker/job.rb
@@ -5,7 +5,8 @@ module SalesforceChunker
     def initialize(connection, query, entity, batch_size)
       @connection = connection
       @batches_count = nil
-      @job_id = create_job(entity, batch_size)
+      headers = {"Sforce-Enable-PKChunking": "true; chunkSize=#{batch_size};" }
+      @job_id = create_job(entity, headers)
       @initial_batch_id = create_batch(query)
     end
 
@@ -51,8 +52,7 @@ module SalesforceChunker
 
     private
 
-    def create_job(entity, batch_size)
-      headers = {"Sforce-Enable-PKChunking": "true; chunkSize=#{batch_size};" }
+    def create_job(entity, headers = {})
       body = {
         "operation": "query",
         "object": entity,

--- a/test/lib/job_test.rb
+++ b/test/lib/job_test.rb
@@ -13,7 +13,7 @@ class JobTest < Minitest::Test
 
   def test_initialize_creates_job_and_batch
     SalesforceChunker::Job.any_instance.expects(:create_job)
-      .with("CustomObject__c", 4300)
+      .with("CustomObject__c", {"Sforce-Enable-PKChunking": "true; chunkSize=4300;"},)
       .returns("3811P00000EFQiYQAZ")
     SalesforceChunker::Job.any_instance.expects(:create_batch)
       .with("Select CustomColumn__c From CustomObject__c")
@@ -126,13 +126,13 @@ class JobTest < Minitest::Test
     connection.expects(:post_json).with(
       "job",
       {"operation": "query", "object": "CustomObject__c", "contentType": "JSON"}.to_json,
-      {"Sforce-Enable-PKChunking": "true; chunkSize=2500;"},
+      {"header": "blah"},
     ).returns({
       "id" => "3811P00000EFQiYQAX"
     })
     @job.instance_variable_set(:@connection, connection)
 
-    @job.send(:create_job, "CustomObject__c", 2500)
+    @job.send(:create_job, "CustomObject__c", {"header": "blah"})
   end
 
   def test_create_batch_sends_request


### PR DESCRIPTION
This PR removes the `private` decorator for most of the `SalesforceChunker::Job` functions. This is because we want to release `SalesforceChunker::Job` to be used by anyone for custom jobs/batches. There isn't any reason why the methods need to be private, except for `create_job`, which can only be done once (on initialization), and `finalize_chunking_setup`, which is a chunking concern and a subfunction.

Also, we are removing the chunking concern (headers) from the `create_job` function.