### PR TITLE
Update and generalize job parameters

### DIFF
--- a/lib/salesforce_chunker.rb
+++ b/lib/salesforce_chunker.rb
@@ -25,7 +25,13 @@ module SalesforceChunker
 
       start_time = Time.now.to_i
       logger.info("#{tag} Initializing Query")
-      job = SalesforceChunker::Job.new(@connection, query, entity, options[:batch_size])
+      job = SalesforceChunker::Job.new(
+        connection: @connection,
+        entity: entity,
+        operation: "query",
+        query: query,
+        batch_size: options[:batch_size],
+      )
       retrieved_batches = []
 
       loop do

--- a/lib/salesforce_chunker/job.rb
+++ b/lib/salesforce_chunker/job.rb
@@ -2,12 +2,13 @@ module SalesforceChunker
   class Job
     attr_reader :batches_count
 
-    def initialize(connection, query, entity, batch_size)
+    def initialize(connection:, entity:, operation:, **options)
       @connection = connection
+      @operation = operation
       @batches_count = nil
-      headers = {"Sforce-Enable-PKChunking": "true; chunkSize=#{batch_size};" }
+      headers = { "Sforce-Enable-PKChunking": "true; chunkSize=#{options[:batch_size]};" }
       @job_id = create_job(entity, headers)
-      @initial_batch_id = create_batch(query)
+      @initial_batch_id = create_batch(options[:query])
     end
 
     def get_completed_batches
@@ -54,7 +55,7 @@ module SalesforceChunker
 
     def create_job(entity, headers = {})
       body = {
-        "operation": "query",
+        "operation": @operation,
         "object": entity,
         "contentType": "JSON"
       }.to_json

--- a/test/lib/job_test.rb
+++ b/test/lib/job_test.rb
@@ -5,7 +5,7 @@ class JobTest < Minitest::Test
   def setup
     SalesforceChunker::Job.any_instance.stubs(:create_job)
     SalesforceChunker::Job.any_instance.stubs(:create_batch)
-    @job = SalesforceChunker::Job.new(nil, "", "", nil)
+    @job = SalesforceChunker::Job.new(connection: nil, entity: nil, operation: nil)
     SalesforceChunker::Job.any_instance.unstub(:create_job)
     SalesforceChunker::Job.any_instance.unstub(:create_batch)
     @job.instance_variable_set(:@job_id, "3811P00000EFQiYQAX")
@@ -18,9 +18,17 @@ class JobTest < Minitest::Test
     SalesforceChunker::Job.any_instance.expects(:create_batch)
       .with("Select CustomColumn__c From CustomObject__c")
       .returns("55024000002iETSAA2")
-    job = SalesforceChunker::Job.new("connect", "Select CustomColumn__c From CustomObject__c", "CustomObject__c", 4300)
+
+    job = SalesforceChunker::Job.new(
+      connection: "connect",
+      entity: "CustomObject__c",
+      operation: "query",
+      query: "Select CustomColumn__c From CustomObject__c",
+      batch_size: 4300,
+    )
 
     assert_equal "connect", job.instance_variable_get(:@connection)
+    assert_equal "query", job.instance_variable_get(:@operation)
     assert_equal "55024000002iETSAA2", job.instance_variable_get(:@initial_batch_id)
     assert_equal "3811P00000EFQiYQAZ", job.instance_variable_get(:@job_id)
   end
@@ -131,6 +139,7 @@ class JobTest < Minitest::Test
       "id" => "3811P00000EFQiYQAX"
     })
     @job.instance_variable_set(:@connection, connection)
+    @job.instance_variable_set(:@operation, "query")
 
     @job.send(:create_job, "CustomObject__c", {"header": "blah"})
   end


### PR DESCRIPTION
This PR updates the `Job` parameters to a hash format, since there could be a lot of them. It makes `connection`, `entity`, and `operation` required since those parameters are always required for a job on salesforce. `query` and `batch_size` are query/pk chunking concerns so they are moved to options.

At this point it does not require changes to the README, because `Client` is not affected. However, at some point, we should document `Job`.