### PR TITLE
Separate job from PK chunking

### DIFF
--- a/lib/salesforce_chunker.rb
+++ b/lib/salesforce_chunker.rb
@@ -1,6 +1,7 @@
 require "salesforce_chunker/connection.rb"
 require "salesforce_chunker/exceptions.rb"
 require "salesforce_chunker/job.rb"
+require "salesforce_chunker/primary_key_chunking_query.rb"
 require 'logger'
 
 module SalesforceChunker
@@ -25,7 +26,7 @@ module SalesforceChunker
 
       start_time = Time.now.to_i
       logger.info("#{tag} Initializing Query")
-      job = SalesforceChunker::Job.new(
+      job = SalesforceChunker::PrimaryKeyChunkingQuery.new(
         connection: @connection,
         entity: entity,
         operation: "query",

--- a/lib/salesforce_chunker/primary_key_chunking_query.rb
+++ b/lib/salesforce_chunker/primary_key_chunking_query.rb
@@ -1,0 +1,33 @@
+module SalesforceChunker
+  class PrimaryKeyChunkingQuery < Job
+
+    def initialize(connection:, entity:, operation:, query:, **options)
+      batch_size = options[:batch_size] || 100000
+
+      if options[:headers].nil?
+        options[:headers] = {"Sforce-Enable-PKChunking": "true; chunkSize=#{batch_size};" }
+      else
+        options[:headers].reverse_merge!({"Sforce-Enable-PKChunking": "true; chunkSize=#{batch_size};" })
+      end
+
+      super(connection: connection, entity: entity, operation: operation, **options)
+      @initial_batch_id = create_batch(query)
+    end
+
+    def get_batch_statuses
+      batches = super
+      finalize_chunking_setup(batches) if @batches_count.nil?
+      batches
+    end
+
+    private
+
+    def finalize_chunking_setup(batches)
+      initial_batch = batches.select { |batch| batch["id"] == @initial_batch_id }.first
+      if initial_batch && initial_batch["state"] == "NotProcessed"
+        @batches_count = batches.length - 1
+        close
+      end
+    end
+  end
+end

--- a/test/lib/job_test.rb
+++ b/test/lib/job_test.rb
@@ -4,32 +4,25 @@ class JobTest < Minitest::Test
 
   def setup
     SalesforceChunker::Job.any_instance.stubs(:create_job)
-    SalesforceChunker::Job.any_instance.stubs(:create_batch)
     @job = SalesforceChunker::Job.new(connection: nil, entity: nil, operation: nil)
     SalesforceChunker::Job.any_instance.unstub(:create_job)
-    SalesforceChunker::Job.any_instance.unstub(:create_batch)
     @job.instance_variable_set(:@job_id, "3811P00000EFQiYQAX")
   end
 
-  def test_initialize_creates_job_and_batch
+  def test_initialize_creates_job
     SalesforceChunker::Job.any_instance.expects(:create_job)
-      .with("CustomObject__c", {"Sforce-Enable-PKChunking": "true; chunkSize=4300;"},)
+      .with("CustomObject__c", nil)
       .returns("3811P00000EFQiYQAZ")
-    SalesforceChunker::Job.any_instance.expects(:create_batch)
-      .with("Select CustomColumn__c From CustomObject__c")
-      .returns("55024000002iETSAA2")
 
     job = SalesforceChunker::Job.new(
       connection: "connect",
       entity: "CustomObject__c",
       operation: "query",
       query: "Select CustomColumn__c From CustomObject__c",
-      batch_size: 4300,
     )
 
     assert_equal "connect", job.instance_variable_get(:@connection)
     assert_equal "query", job.instance_variable_get(:@operation)
-    assert_equal "55024000002iETSAA2", job.instance_variable_get(:@initial_batch_id)
     assert_equal "3811P00000EFQiYQAZ", job.instance_variable_get(:@job_id)
   end
 
@@ -44,63 +37,6 @@ class JobTest < Minitest::Test
     @job.instance_variable_set(:@connection, connection)
 
     assert_equal 2, @job.get_batch_statuses.size
-  end
-
-  def test_get_batch_status_calls_finalize_chunking_setup_when_batches_count_is_nil
-    connection = mock()
-    connection.expects(:get_json).with(
-      "job/3811P00000EFQiYQAX/batch",
-    ).returns({"batchInfo" => [
-      {"id"=> "55024000002iETSAA2", "state"=> "Completed"},
-      {"id"=> "55024000002iETTAA2", "state"=> "InProgress"},
-    ]})
-    @job.instance_variable_set(:@connection, connection)
-    @job.instance_variable_set(:@batches_count, nil)
-    @job.expects(:finalize_chunking_setup)
-
-    @job.get_batch_statuses
-  end
-
-  def test_get_batch_status_doesnt_call_finalize_chunking_setup_when_batches_count_is_not_nil
-    connection = mock()
-    connection.expects(:get_json).with(
-      "job/3811P00000EFQiYQAX/batch",
-    ).returns({"batchInfo" => [
-      {"id"=> "55024000002iETSAA2", "state"=> "NotProcessed"},
-      {"id"=> "55024000002iETTAA2", "state"=> "InProgress"},
-      {"id"=> "55024000002iETUAA2", "state"=> "InProgress"},
-      {"id"=> "55024000002iETVAA2", "state"=> "Completed"},
-    ]})
-    @job.instance_variable_set(:@connection, connection)
-    @job.instance_variable_set(:@batches_count, 3)
-    @job.expects(:finalize_chunking_setup).never
-
-    @job.get_batch_statuses
-  end
-
-  def test_finalize_chunking_setup_sets_batches_count_and_closes_once_initial_batch_is_ready
-    batches = [
-      {"id"=> "55024000002iETSAA2", "state"=> "NotProcessed"},
-      {"id"=> "55024000002iETTAA2", "state"=> "InProgress"},
-      {"id"=> "55024000002iETUAA2", "state"=> "InProgress"},
-      {"id"=> "55024000002iETVAA2", "state"=> "Completed"},
-    ]
-    @job.instance_variable_set(:@initial_batch_id, "55024000002iETSAA2")
-    @job.expects(:close)
-
-    @job.send(:finalize_chunking_setup, batches)
-    assert_equal 3, @job.instance_variable_get(:@batches_count)
-  end
-
-  def test_finalize_chunking_setup_doesnt_set_batches_count_or_close_before_initial_batch_is_ready
-    batches = [
-      {"id"=> "55024000002iETSAA2", "state"=> "Queued"},
-    ]
-    @job.instance_variable_set(:@initial_batch_id, "55024000002iETSAA2")
-    @job.expects(:close).never
-
-    @job.send(:finalize_chunking_setup, batches)
-    assert_nil @job.instance_variable_get(:@batches_count)
   end
 
   def test_get_batch_results_retrieves_all_results

--- a/test/lib/primary_key_chunking_query_test.rb
+++ b/test/lib/primary_key_chunking_query_test.rb
@@ -1,0 +1,94 @@
+require "test_helper"
+
+class PrimaryKeyChunkingQueryTest < Minitest::Test
+
+  def setup
+    SalesforceChunker::PrimaryKeyChunkingQuery.any_instance.stubs(:create_job)
+    SalesforceChunker::PrimaryKeyChunkingQuery.any_instance.stubs(:create_batch)
+    @job = SalesforceChunker::PrimaryKeyChunkingQuery.new(connection: nil, entity: nil, operation: nil, query: nil)
+    SalesforceChunker::PrimaryKeyChunkingQuery.any_instance.unstub(:create_job)
+    SalesforceChunker::PrimaryKeyChunkingQuery.any_instance.unstub(:create_batch)
+    @job.instance_variable_set(:@job_id, "3811P00000EFQiYQAX")
+  end
+
+  def test_initialize_creates_job_and_batch
+    SalesforceChunker::Job.any_instance.expects(:create_job)
+      .with("CustomObject__c", {"Sforce-Enable-PKChunking": "true; chunkSize=4300;"})
+      .returns("3811P00000EFQiYQAZ")
+    SalesforceChunker::Job.any_instance.expects(:create_batch)
+      .with("Select CustomColumn__c From CustomObject__c")
+      .returns("55024000002iETSAA2")
+
+    job = SalesforceChunker::PrimaryKeyChunkingQuery.new(
+      connection: "connect",
+      entity: "CustomObject__c",
+      operation: "query",
+      query: "Select CustomColumn__c From CustomObject__c",
+      batch_size: 4300,
+    )
+
+    assert_equal "connect", job.instance_variable_get(:@connection)
+    assert_equal "query", job.instance_variable_get(:@operation)
+    assert_equal "55024000002iETSAA2", job.instance_variable_get(:@initial_batch_id)
+    assert_equal "3811P00000EFQiYQAZ", job.instance_variable_get(:@job_id)
+  end
+
+
+  def test_get_batch_status_calls_finalize_chunking_setup_when_batches_count_is_nil
+    connection = mock()
+    connection.expects(:get_json).with(
+      "job/3811P00000EFQiYQAX/batch",
+    ).returns({"batchInfo" => [
+      {"id"=> "55024000002iETSAA2", "state"=> "Completed"},
+      {"id"=> "55024000002iETTAA2", "state"=> "InProgress"},
+    ]})
+    @job.instance_variable_set(:@connection, connection)
+    @job.instance_variable_set(:@batches_count, nil)
+    @job.expects(:finalize_chunking_setup)
+
+    @job.get_batch_statuses
+  end
+
+  def test_get_batch_status_doesnt_call_finalize_chunking_setup_when_batches_count_is_not_nil
+    connection = mock()
+    connection.expects(:get_json).with(
+      "job/3811P00000EFQiYQAX/batch",
+    ).returns({"batchInfo" => [
+      {"id"=> "55024000002iETSAA2", "state"=> "NotProcessed"},
+      {"id"=> "55024000002iETTAA2", "state"=> "InProgress"},
+      {"id"=> "55024000002iETUAA2", "state"=> "InProgress"},
+      {"id"=> "55024000002iETVAA2", "state"=> "Completed"},
+    ]})
+    @job.instance_variable_set(:@connection, connection)
+    @job.instance_variable_set(:@batches_count, 3)
+    @job.expects(:finalize_chunking_setup).never
+
+    @job.get_batch_statuses
+  end
+
+  def test_finalize_chunking_setup_sets_batches_count_and_closes_once_initial_batch_is_ready
+    batches = [
+      {"id"=> "55024000002iETSAA2", "state"=> "NotProcessed"},
+      {"id"=> "55024000002iETTAA2", "state"=> "InProgress"},
+      {"id"=> "55024000002iETUAA2", "state"=> "InProgress"},
+      {"id"=> "55024000002iETVAA2", "state"=> "Completed"},
+    ]
+    @job.instance_variable_set(:@initial_batch_id, "55024000002iETSAA2")
+    @job.expects(:close)
+
+    @job.send(:finalize_chunking_setup, batches)
+    assert_equal 3, @job.instance_variable_get(:@batches_count)
+  end
+
+  def test_finalize_chunking_setup_doesnt_set_batches_count_or_close_before_initial_batch_is_ready
+    batches = [
+      {"id"=> "55024000002iETSAA2", "state"=> "Queued"},
+    ]
+    @job.instance_variable_set(:@initial_batch_id, "55024000002iETSAA2")
+    @job.expects(:close).never
+
+    @job.send(:finalize_chunking_setup, batches)
+    assert_nil @job.instance_variable_get(:@batches_count)
+  end
+
+end

--- a/test/salesforce_chunker_test.rb
+++ b/test/salesforce_chunker_test.rb
@@ -23,7 +23,7 @@ class SalesforceChunkerTest < Minitest::Test
     job.expects(:get_completed_batches).at_least_once.returns([])
     job.expects(:batches_count).at_least_once.returns(1)
 
-    SalesforceChunker::Job.stubs(:new).returns(job)
+    SalesforceChunker::PrimaryKeyChunkingQuery.stubs(:new).returns(job)
     assert_raises SalesforceChunker::TimeoutError do
       @client.query("", "", retry_seconds: 0, timeout_seconds: 0) do |result|
         yield(result)
@@ -65,7 +65,7 @@ class SalesforceChunkerTest < Minitest::Test
       {"CustomColumn__c" => "jkl"},
     ]
 
-    SalesforceChunker::Job.stubs(:new).returns(job)
+    SalesforceChunker::PrimaryKeyChunkingQuery.stubs(:new).returns(job)
     @client.query("", "", retry_seconds: 0) { |result| actual_results << result }
     assert_equal expected_results, actual_results
   end


### PR DESCRIPTION
This PR separates the PK chunking concern from the general `Job` interface that can be reused for other purposes.

