### PR TITLE
Create SingleBatchJob

### DIFF
--- a/lib/salesforce_chunker.rb
+++ b/lib/salesforce_chunker.rb
@@ -1,6 +1,7 @@
 require "salesforce_chunker/connection.rb"
 require "salesforce_chunker/exceptions.rb"
 require "salesforce_chunker/job.rb"
+require "salesforce_chunker/single_batch_job.rb"
 require "salesforce_chunker/primary_key_chunking_query.rb"
 require 'logger'
 

--- a/lib/salesforce_chunker/single_batch_job.rb
+++ b/lib/salesforce_chunker/single_batch_job.rb
@@ -1,0 +1,10 @@
+module SalesforceChunker
+  class SingleBatchJob < Job
+    def initialize(connection:, entity:, operation:, payload:, **options)
+      super(connection: connection, entity: entity, operation: operation, **options)
+      @batch_id = create_batch(payload)
+      @batches_count = 1
+      close
+    end
+  end
+end

--- a/test/lib/single_batch_job_test.rb
+++ b/test/lib/single_batch_job_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class SingleBatchJobTest < Minitest::Test
+
+  def test_initialize_creates_job_and_batch_and_closes
+    SalesforceChunker::SingleBatchJob.any_instance.expects(:create_job)
+      .with("Object", nil)
+      .returns("3811P00000EFQiYQAG")
+
+    SalesforceChunker::SingleBatchJob.any_instance.expects(:create_batch)
+      .with("Select Id from Object")
+      .returns("3811P00000EFQiYQAJ")
+
+    SalesforceChunker::SingleBatchJob.any_instance.expects(:close)
+
+    job = SalesforceChunker::SingleBatchJob.new(
+      connection: "connect",
+      entity: "Object",
+      operation: "query",
+      payload: "Select Id from Object",
+    )
+
+    assert_equal "connect", job.instance_variable_get(:@connection)
+    assert_equal "query", job.instance_variable_get(:@operation)
+    assert_equal "3811P00000EFQiYQAG", job.instance_variable_get(:@job_id)
+    assert_equal "3811P00000EFQiYQAJ", job.instance_variable_get(:@batch_id)
+    assert_equal 1, job.instance_variable_get(:@batches_count)
+  end
+end


### PR DESCRIPTION
This is a pattern when one wants to use the Salesforce Bulk API to perform an asynchronous request, but they don't want to split up their operation (query, insert, etc.) into multiple batches. A reason for this is if they only have ie a few thousand records to insert or less than a million records to download. 

This automatically handles the batch creation and closing of the job in the initialization.

