### PR TITLE
Move downloading results code to the Job class

### DIFF
--- a/lib/salesforce_chunker.rb
+++ b/lib/salesforce_chunker.rb
@@ -12,53 +12,26 @@ module SalesforceChunker
     end
 
     def query(query, entity, **options)
-      default_options = {
-        batch_size: 100000,
-        retry_seconds: 10,
-        timeout_seconds: 3600,
-      }
-      options = default_options.merge(options)
-
-      logger = options[:logger] || Logger.new(options[:log_output])
-      tag = "[salesforce_chunker]"
-
       raise StandardError, "No block given" unless block_given?
 
-      start_time = Time.now.to_i
-      logger.info("#{tag} Initializing Query")
       job = SalesforceChunker::PrimaryKeyChunkingQuery.new(
         connection: @connection,
         entity: entity,
         operation: "query",
         query: query,
         batch_size: options[:batch_size],
+        logger: options[:logger],
+        log_output: options[:log_output],
       )
-      retrieved_batches = []
 
-      loop do
-        logger.info("#{tag} Retrieving batch status information")
-        job.get_completed_batches.each do |batch|
-          next if retrieved_batches.include?(batch["id"])
+      download_options = {
+        timeout: options[:timeout],
+        retry_seconds: options[:retry_seconds],
+      }
 
-          logger.info("#{tag} Batch #{retrieved_batches.length + 1} of #{job.batches_count || '?'}: " \
-            "retrieving #{batch["numberRecordsProcessed"]} records")
-          if batch["numberRecordsProcessed"] > 0
-            job.get_batch_results(batch["id"]) do |result|
-              yield(result)
-            end
-          end
-          retrieved_batches.append(batch["id"])
-        end
-
-        break if job.batches_count && retrieved_batches.length == job.batches_count
-
-        raise TimeoutError, "Timeout during batch processing" if (Time.now.to_i - start_time) > options[:timeout_seconds]
-
-        logger.info("#{tag} Waiting #{options[:retry_seconds]} seconds")
-        sleep(options[:retry_seconds])
+      job.download_results(**download_options) do |result|
+        yield(result)
       end
-
-      logger.info("#{tag} Completed")
     end
   end
 end

--- a/test/salesforce_chunker_test.rb
+++ b/test/salesforce_chunker_test.rb
@@ -18,54 +18,17 @@ class SalesforceChunkerTest < Minitest::Test
     end
   end
 
-  def test_raise_timeout_error_when_query_exceeds_timeout_seconds
+  def test_query
     job = mock()
-    job.expects(:get_completed_batches).at_least_once.returns([])
-    job.expects(:batches_count).at_least_once.returns(1)
-
-    SalesforceChunker::PrimaryKeyChunkingQuery.stubs(:new).returns(job)
-    assert_raises SalesforceChunker::TimeoutError do
-      @client.query("", "", retry_seconds: 0, timeout_seconds: 0) do |result|
-        yield(result)
-      end
-    end
-  end
-
-  def test_query_yields_batch_results
-    job = mock()
-
-    first_completed_batches = [
-      {"id" => "55024000002iETUAA2", "state" => "Completed", "numberRecordsFailed" => 0, "numberRecordsProcessed" => 3},
-    ]
-
-    second_completed_batches = [
-      {"id" => "55024000002iETTAA2", "state" => "Completed", "numberRecordsFailed" => 0, "numberRecordsProcessed" => 1},
-      {"id" => "55024000002iETUAA2", "state" => "Completed", "numberRecordsFailed" => 0, "numberRecordsProcessed" => 3},
-    ]
-
-    job.expects(:get_completed_batches).twice.returns(first_completed_batches, second_completed_batches)
-
-    job.expects(:get_batch_results).with("55024000002iETUAA2").multiple_yields(
-      [{"CustomColumn__c" => "abc"}],
-      [{"CustomColumn__c" => "def"}],
-      [{"CustomColumn__c" => "ghi"}],
-    )
-
-    job.expects(:get_batch_results).with("55024000002iETTAA2").yields(
-      {"CustomColumn__c" => "jkl"},
-    )
-
-    job.expects(:batches_count).times(6).returns(2)
+    job.expects(:download_results).yields({"CustomColumn__c" => "abc"})
 
     actual_results = []
     expected_results = [
       {"CustomColumn__c" => "abc"},
-      {"CustomColumn__c" => "def"},
-      {"CustomColumn__c" => "ghi"},
-      {"CustomColumn__c" => "jkl"},
     ]
 
     SalesforceChunker::PrimaryKeyChunkingQuery.stubs(:new).returns(job)
+
     @client.query("", "", retry_seconds: 0) { |result| actual_results << result }
     assert_equal expected_results, actual_results
   end


### PR DESCRIPTION
This PR moves the code downloading results from the query out of the `Client` (which we should keep lightweight) and into the `Job` class.

It also moves logging around as well, and also some tests.

I need to squash commits as well as test this manually