### PR TITLE
Fix bug that causes error when headers are not included

### DIFF
--- a/lib/salesforce_chunker/job.rb
+++ b/lib/salesforce_chunker/job.rb
@@ -15,7 +15,7 @@ module SalesforceChunker
       @batches_count = nil
 
       @log.info "Creating Bulk API Job"
-      @job_id = create_job(entity, options[:headers])
+      @job_id = create_job(entity, options[:headers].to_h)
     end
 
     def download_results(**options)

--- a/test/lib/job_test.rb
+++ b/test/lib/job_test.rb
@@ -11,7 +11,7 @@ class JobTest < Minitest::Test
 
   def test_initialize_creates_job
     SalesforceChunker::Job.any_instance.expects(:create_job)
-      .with("CustomObject__c", nil)
+      .with("CustomObject__c", {})
       .returns("3811P00000EFQiYQAZ")
 
     job = SalesforceChunker::Job.new(


### PR DESCRIPTION
If `options[:headers]` is not set, it causes an error in `post` in `SalesforceChunker::Connection`:
`NoMethodError (undefined method 'merge' for nil:NilClass)`

This fixes the issue and just sets it to `{}`

This doesn't affect PK Chunking because it uses headers, but it causes issues with everything else.