### PR TITLE
Add single_batch_query to client

### DIFF
--- a/test/salesforce_chunker_test.rb
+++ b/test/salesforce_chunker_test.rb
@@ -32,4 +32,29 @@ class SalesforceChunkerTest < Minitest::Test
     @client.query("", "", retry_seconds: 0) { |result| actual_results << result }
     assert_equal expected_results, actual_results
   end
+
+  def test_query_with_job_type_single_batch
+    job = mock()
+    job.expects(:download_results).yields({"CustomColumn__c" => "abc"})
+
+    actual_results = []
+    expected_results = [
+      {"CustomColumn__c" => "abc"},
+    ]
+
+    SalesforceChunker::SingleBatchJob.stubs(:new).returns(job)
+
+    @client.query("", "", retry_seconds: 0, job_type: "single_batch") { |result| actual_results << result }
+    assert_equal expected_results, actual_results
+  end
+
+  def test_single_batch_query
+    @client.expects(:query).with("q", "e", job_type: "single_batch")
+    @client.single_batch_query("q", "e") {}
+  end
+
+  def test_primary_key_chunking_query
+    @client.expects(:query).with("q", "e", job_type: "primary_key_chunking")
+    @client.primary_key_chunking_query("q", "e") {}
+  end
 end


### PR DESCRIPTION
This allows `client.single_batch_query` to be run, and it will not do any multi-batching or pk chunking