### PR TITLE
Clean up Connection class

### DIFF
--- a/lib/salesforce_chunker/connection.rb
+++ b/lib/salesforce_chunker/connection.rb
@@ -21,13 +21,12 @@ module SalesforceChunker
 
       result = response["Envelope"]["Body"]["loginResponse"]["result"]
 
-      @session_id = result["sessionId"]
-      @instance = self.class.get_instance(result["serverUrl"])
+      instance = self.class.get_instance(result["serverUrl"])
 
-      @base_url = "https://#{@instance}.salesforce.com/services/async/#{options[:salesforce_version]}/"
+      @base_url = "https://#{instance}.salesforce.com/services/async/#{options[:salesforce_version]}/"
       @default_headers = {
         "Content-Type": "application/json",
-        "X-SFDC-Session": @session_id,
+        "X-SFDC-Session": result["sessionId"],
         "Accept-Encoding": "gzip",
       }
     rescue NoMethodError


### PR DESCRIPTION
This PR does 3 things:

1. moves SOAP XML text to its own function instead of the middle of `initialize`
2. Rearranges the `rescue` to remove the `begin` and use the function instead.
3. Don't set instance variables that don't need to be instance variables