### PR TITLE
fix payload query bug and naming issues

### DIFF
--- a/lib/salesforce_chunker/job.rb
+++ b/lib/salesforce_chunker/job.rb
@@ -63,11 +63,11 @@ module SalesforceChunker
       end
     end
 
-    def create_batch(data)
+    def create_batch(payload)
       if QUERY_OPERATIONS.include?(@operation)
-        @connection.post("job/#{@job_id}/batch", data.to_s)["id"]
+        @connection.post("job/#{@job_id}/batch", payload.to_s)["id"]
       else
-        @connection.post_json("job/#{@job_id}/batch", data)["id"]
+        @connection.post_json("job/#{@job_id}/batch", payload)["id"]
       end
     end
 

--- a/lib/salesforce_chunker/single_batch_job.rb
+++ b/lib/salesforce_chunker/single_batch_job.rb
@@ -1,7 +1,8 @@
 module SalesforceChunker
   class SingleBatchJob < Job
-    def initialize(connection:, entity:, operation:, payload:, **options)
+    def initialize(connection:, entity:, operation:, **options)
       super(connection: connection, entity: entity, operation: operation, **options)
+      payload = options[:payload] || options[:query]
       @batch_id = create_batch(payload)
       @batches_count = 1
       close

--- a/test/lib/single_batch_job_test.rb
+++ b/test/lib/single_batch_job_test.rb
@@ -17,7 +17,7 @@ class SingleBatchJobTest < Minitest::Test
       connection: "connect",
       entity: "Object",
       operation: "query",
-      payload: "Select Id from Object",
+      query: "Select Id from Object",
     )
 
     assert_equal "connect", job.instance_variable_get(:@connection)
@@ -25,5 +25,24 @@ class SingleBatchJobTest < Minitest::Test
     assert_equal "3811P00000EFQiYQAG", job.instance_variable_get(:@job_id)
     assert_equal "3811P00000EFQiYQAJ", job.instance_variable_get(:@batch_id)
     assert_equal 1, job.instance_variable_get(:@batches_count)
+  end
+
+  def test_payload_option
+    SalesforceChunker::SingleBatchJob.any_instance.expects(:create_job)
+      .with("Object", {})
+      .returns("3811P00000EFQiYQAG")
+
+    SalesforceChunker::SingleBatchJob.any_instance.expects(:create_batch)
+      .with([{"FirstName": "Foo", "LastName": "Bar"}])
+      .returns("3811P00000EFQiYQAJ")
+
+    SalesforceChunker::SingleBatchJob.any_instance.expects(:close)
+
+    job = SalesforceChunker::SingleBatchJob.new(
+      connection: "connect",
+      entity: "Object",
+      operation: "upsert",
+      payload: [{"FirstName": "Foo", "LastName": "Bar"}],
+    )
   end
 end


### PR DESCRIPTION
This PR allows `SingleBatchJob` to be used with either `payload` or `query`.

In general, `payload` refers to JSON data being sent to Salesforce, and `query` represents a SOQL string telling Salesforce what data to send back.

- [x] tested manually