### PR TITLE
Rename entity to object

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ client = SalesforceChunker::Client.new(
 
 ```ruby
 query = "Select Name from Account" # required. SOQL query.
-entity = "Account"                 # required. Sobject type.
+object = "Account"                 # required. Salesforce object type.
 options = {
   batch_size:       100000,              
   retry_seconds:    10,               
@@ -78,7 +78,7 @@ options = {
   job_type:         "primary_key_chunking",
 }
 
-client.query(query, entity, options) do |result|
+client.query(query, object, options) do |result|
   process(result)
 end
 ```
@@ -95,7 +95,7 @@ end
 `query` can either be called with a block, or will return an enumerator:
 
 ```ruby
-names = client.query(query, entity, options).map { |result| result["Name"] }
+names = client.query(query, object, options).map { |result| result["Name"] }
 ```
 
 ### Under the hood: SalesforceChunker::Job

--- a/lib/salesforce_chunker.rb
+++ b/lib/salesforce_chunker.rb
@@ -12,8 +12,8 @@ module SalesforceChunker
       @connection = SalesforceChunker::Connection.new(**options)
     end
 
-    def query(query, entity, **options)
-      return to_enum(:query, query, entity, **options) unless block_given?
+    def query(query, object, **options)
+      return to_enum(:query, query, object, **options) unless block_given?
 
       case options[:job_type]
       when "single_batch"
@@ -24,7 +24,7 @@ module SalesforceChunker
 
       job = job_class.new(
         connection: @connection,
-        entity: entity,
+        object: object,
         operation: "query",
         query: query,
         **options.slice(:batch_size, :logger, :log_output)
@@ -33,12 +33,12 @@ module SalesforceChunker
       job.download_results(**options.slice(:timeout, :retry_seconds)) { |result| yield(result) }
     end
 
-    def single_batch_query(query, entity, **options)
-      query(query, entity, **options.merge(job_type: "single_batch"))
+    def single_batch_query(query, object, **options)
+      query(query, object, **options.merge(job_type: "single_batch"))
     end
 
-    def primary_key_chunking_query(query, entity, **options)
-      query(query, entity, **options.merge(job_type: "primary_key_chunking"))
+    def primary_key_chunking_query(query, object, **options)
+      query(query, object, **options.merge(job_type: "primary_key_chunking"))
     end
   end
 end

--- a/lib/salesforce_chunker/job.rb
+++ b/lib/salesforce_chunker/job.rb
@@ -6,7 +6,7 @@ module SalesforceChunker
     DEFAULT_RETRY_SECONDS = 10
     DEFAULT_TIMEOUT_SECONDS = 3600
 
-    def initialize(connection:, entity:, operation:, **options)
+    def initialize(connection:, object:, operation:, **options)
       @log = options[:logger] || Logger.new(options[:log_output])
       @log.progname = "salesforce_chunker"
 
@@ -15,7 +15,7 @@ module SalesforceChunker
       @batches_count = nil
 
       @log.info "Creating Bulk API Job"
-      @job_id = create_job(entity, options[:headers].to_h)
+      @job_id = create_job(object, options[:headers].to_h)
     end
 
     def download_results(**options)
@@ -92,10 +92,10 @@ module SalesforceChunker
 
     private
 
-    def create_job(entity, headers = {})
+    def create_job(object, headers = {})
       body = {
         "operation": @operation,
-        "object": entity,
+        "object": object,
         "contentType": "JSON"
       }
       @connection.post_json("job", body, headers)["id"]

--- a/lib/salesforce_chunker/primary_key_chunking_query.rb
+++ b/lib/salesforce_chunker/primary_key_chunking_query.rb
@@ -1,7 +1,7 @@
 module SalesforceChunker
   class PrimaryKeyChunkingQuery < Job
 
-    def initialize(connection:, entity:, operation:, query:, **options)
+    def initialize(connection:, object:, operation:, query:, **options)
       batch_size = options[:batch_size] || 100000
 
       if options[:headers].nil?
@@ -10,7 +10,7 @@ module SalesforceChunker
         options[:headers].reverse_merge!({"Sforce-Enable-PKChunking": "true; chunkSize=#{batch_size};" })
       end
 
-      super(connection: connection, entity: entity, operation: operation, **options)
+      super(connection: connection, object: object, operation: operation, **options)
       @log.info "Using Primary Key Chunking"
       @initial_batch_id = create_batch(query)
     end

--- a/lib/salesforce_chunker/single_batch_job.rb
+++ b/lib/salesforce_chunker/single_batch_job.rb
@@ -1,7 +1,7 @@
 module SalesforceChunker
   class SingleBatchJob < Job
-    def initialize(connection:, entity:, operation:, **options)
-      super(connection: connection, entity: entity, operation: operation, **options)
+    def initialize(connection:, object:, operation:, **options)
+      super(connection: connection, object: object, operation: operation, **options)
       payload = options[:payload] || options[:query]
       @log.info "Using Single Batch"
       @batch_id = create_batch(payload)

--- a/test/lib/job_test.rb
+++ b/test/lib/job_test.rb
@@ -4,7 +4,7 @@ class JobTest < Minitest::Test
 
   def setup
     SalesforceChunker::Job.any_instance.stubs(:create_job)
-    @job = SalesforceChunker::Job.new(connection: nil, entity: nil, operation: nil)
+    @job = SalesforceChunker::Job.new(connection: nil, object: nil, operation: nil)
     SalesforceChunker::Job.any_instance.unstub(:create_job)
     @job.instance_variable_set(:@job_id, "3811P00000EFQiYQAX")
   end
@@ -16,7 +16,7 @@ class JobTest < Minitest::Test
 
     job = SalesforceChunker::Job.new(
       connection: "connect",
-      entity: "CustomObject__c",
+      object: "CustomObject__c",
       operation: "query",
       query: "Select CustomColumn__c From CustomObject__c",
     )

--- a/test/lib/primary_key_chunking_query_test.rb
+++ b/test/lib/primary_key_chunking_query_test.rb
@@ -5,7 +5,7 @@ class PrimaryKeyChunkingQueryTest < Minitest::Test
   def setup
     SalesforceChunker::PrimaryKeyChunkingQuery.any_instance.stubs(:create_job)
     SalesforceChunker::PrimaryKeyChunkingQuery.any_instance.stubs(:create_batch)
-    @job = SalesforceChunker::PrimaryKeyChunkingQuery.new(connection: nil, entity: nil, operation: nil, query: nil)
+    @job = SalesforceChunker::PrimaryKeyChunkingQuery.new(connection: nil, object: nil, operation: nil, query: nil)
     SalesforceChunker::PrimaryKeyChunkingQuery.any_instance.unstub(:create_job)
     SalesforceChunker::PrimaryKeyChunkingQuery.any_instance.unstub(:create_batch)
     @job.instance_variable_set(:@job_id, "3811P00000EFQiYQAX")
@@ -21,7 +21,7 @@ class PrimaryKeyChunkingQueryTest < Minitest::Test
 
     job = SalesforceChunker::PrimaryKeyChunkingQuery.new(
       connection: "connect",
-      entity: "CustomObject__c",
+      object: "CustomObject__c",
       operation: "query",
       query: "Select CustomColumn__c From CustomObject__c",
       batch_size: 4300,

--- a/test/lib/single_batch_job_test.rb
+++ b/test/lib/single_batch_job_test.rb
@@ -15,7 +15,7 @@ class SingleBatchJobTest < Minitest::Test
 
     job = SalesforceChunker::SingleBatchJob.new(
       connection: "connect",
-      entity: "Object",
+      object: "Object",
       operation: "query",
       query: "Select Id from Object",
     )
@@ -40,7 +40,7 @@ class SingleBatchJobTest < Minitest::Test
 
     job = SalesforceChunker::SingleBatchJob.new(
       connection: "connect",
-      entity: "Object",
+      object: "Object",
       operation: "upsert",
       payload: [{"FirstName": "Foo", "LastName": "Bar"}],
     )

--- a/test/salesforce_chunker_test.rb
+++ b/test/salesforce_chunker_test.rb
@@ -46,12 +46,12 @@ class SalesforceChunkerTest < Minitest::Test
   end
 
   def test_single_batch_query
-    @client.expects(:query).with("q", "e", job_type: "single_batch")
-    @client.single_batch_query("q", "e") {}
+    @client.expects(:query).with("q", "o", job_type: "single_batch")
+    @client.single_batch_query("q", "o") {}
   end
 
   def test_primary_key_chunking_query
-    @client.expects(:query).with("q", "e", job_type: "primary_key_chunking")
-    @client.primary_key_chunking_query("q", "e") {}
+    @client.expects(:query).with("q", "o", job_type: "primary_key_chunking")
+    @client.primary_key_chunking_query("q", "o") {}
   end
 end


### PR DESCRIPTION
This isn't yet used as a hash parameter, so this shouldn't affect any usage of the gem, only internal naming. (Although, it will eventually be exposed as a hash parameter). 

Salesforce uses the term "Object" to refer to it's data types. We should be consistent with that.

We want to keep `query`. SOQL (Salesforce Object Query Language) refers to the language it is in, not what it is (a query). `soql_query` is too verbose, contains "query" twice, and mixes an acronym with a full word.

tested manually