### PR TITLE
Set externalIdFieldName on Upsert

### DIFF
--- a/lib/salesforce_chunker/job.rb
+++ b/lib/salesforce_chunker/job.rb
@@ -15,7 +15,7 @@ module SalesforceChunker
       @batches_count = nil
 
       @log.info "Creating Bulk API Job"
-      @job_id = create_job(object, options[:headers].to_h)
+      @job_id = create_job(object, options.slice(:headers, :external_id))
     end
 
     def download_results(**options)
@@ -92,13 +92,14 @@ module SalesforceChunker
 
     private
 
-    def create_job(object, headers = {})
+    def create_job(object, options)
       body = {
         "operation": @operation,
         "object": object,
-        "contentType": "JSON"
+        "contentType": "JSON",
       }
-      @connection.post_json("job", body, headers)["id"]
+      body[:externalIdFieldName] = options[:external_id] if @operation == "upsert"
+      @connection.post_json("job", body, options[:headers].to_h)["id"]
     end
   end
 end

--- a/test/lib/job_test.rb
+++ b/test/lib/job_test.rb
@@ -70,14 +70,29 @@ class JobTest < Minitest::Test
     connection.expects(:post_json).with(
       "job",
       {"operation": "query", "object": "CustomObject__c", "contentType": "JSON"},
-      {"header": "blah"},
+      {"foo": "bar"},
     ).returns({
       "id" => "3811P00000EFQiYQAX"
     })
     @job.instance_variable_set(:@connection, connection)
     @job.instance_variable_set(:@operation, "query")
 
-    @job.send(:create_job, "CustomObject__c", {"header": "blah"})
+    @job.send(:create_job, "CustomObject__c", {"headers": {"foo": "bar"}})
+  end
+
+  def test_create_job_uses_external_id
+    connection = mock()
+    connection.expects(:post_json).with(
+      "job",
+      {"operation": "upsert", "object": "CustomObject__c", "contentType": "JSON", "externalIdFieldName": "Field__c"},
+      {},
+    ).returns({
+      "id" => "3811P00000EFQiYQAX"
+    })
+    @job.instance_variable_set(:@connection, connection)
+    @job.instance_variable_set(:@operation, "upsert")
+
+    @job.send(:create_job, "CustomObject__c", {"external_id": "Field__c"})
   end
 
   def test_create_batch_sends_query_as_string

--- a/test/lib/primary_key_chunking_query_test.rb
+++ b/test/lib/primary_key_chunking_query_test.rb
@@ -13,7 +13,7 @@ class PrimaryKeyChunkingQueryTest < Minitest::Test
 
   def test_initialize_creates_job_and_batch
     SalesforceChunker::Job.any_instance.expects(:create_job)
-      .with("CustomObject__c", {"Sforce-Enable-PKChunking": "true; chunkSize=4300;"})
+      .with("CustomObject__c", { headers: { "Sforce-Enable-PKChunking": "true; chunkSize=4300;" }})
       .returns("3811P00000EFQiYQAZ")
     SalesforceChunker::Job.any_instance.expects(:create_batch)
       .with("Select CustomColumn__c From CustomObject__c")


### PR DESCRIPTION
Currently, upsert jobs don't work correctly because they need an `externalIdFieldName` to be set on job creation.

This fixes the issue and allows `external_id:` to be set on Job creation for upserts.

tested manually