### PR TITLE
allow gem pushes

### DIFF
--- a/salesforce_chunker.gemspec
+++ b/salesforce_chunker.gemspec
@@ -14,15 +14,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/Shopify/salesforce_chunker'
   spec.license       = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
Now that this gem is open source, we want to allow pushes to rubygems.org, etc.