### PR TITLE
allow connection default_headers to be overridden

### DIFF
--- a/lib/salesforce_chunker/connection.rb
+++ b/lib/salesforce_chunker/connection.rb
@@ -30,13 +30,13 @@ module SalesforceChunker
     end
 
     def post(url, body, headers={})
-      response = HTTParty.post(@base_url + url, headers: headers.merge(@default_headers), body: body).parsed_response
-      self.class.check_response_error(response)
+      response = HTTParty.post(@base_url + url, headers: @default_headers.merge(headers), body: body)
+      self.class.check_response_error(response.parsed_response)
     end
 
     def get_json(url, headers={})
-      response = HTTParty.get(@base_url + url, headers: headers.merge(@default_headers)).parsed_response
-      self.class.check_response_error(response)
+      response = HTTParty.get(@base_url + url, headers: @default_headers.merge(headers))
+      self.class.check_response_error(response.parsed_response)
     end
 
     private

--- a/test/lib/connection_test.rb
+++ b/test/lib/connection_test.rb
@@ -58,6 +58,19 @@ class ConnectionTest < Minitest::Test
     assert_equal 1234, response
   end
 
+  def test_headers_can_be_overridden
+    expected_url = "https://na99.salesforce.com/services/async/42.0/getroute"
+    expected_headers = {
+      "Content-Type": "text/csv",
+      "X-SFDC-Session": "3ea96c71f254c3f2e6ce3a2b2b723c87",
+      "Accept-Encoding": "gzip",
+      "Foo": "bar",
+    }
+    HTTParty.expects(:get).with(expected_url, headers: expected_headers).returns(json_response)
+
+    response = @connection.get_json("getroute", {"Content-Type": "text/csv", "Foo": "bar"})
+  end
+
   def test_get_instance_extracts_instance
     urls = [
       "https://na99.salesforce.com/something",


### PR DESCRIPTION
This PR makes the default headers actually "default", and not "set in stone".

Probably no reason to change "X-SFDC-Session" or "Accept-Encoding", but we will be experimenting with changing around "Content-Type" in the near future, so this will be helpful.

Also, moving the `parsed_response` down to the next line is helpful for development. A `binding.pry` can be placed into the line between them to inspect `response` instead of `parsed_response`.

This should be generally backwards compatible unless this code has been extended in a really weird way. 

Adds a test as well.

- [x] tests passing
- [x] manual testing 