### PR TITLE
add logging to connection class

### DIFF
--- a/lib/salesforce_chunker/connection.rb
+++ b/lib/salesforce_chunker/connection.rb
@@ -3,7 +3,9 @@ require "httparty"
 module SalesforceChunker
   class Connection
 
-    def initialize(username: "", password: "", security_token: "", domain: "login", salesforce_version: "42.0")
+    def initialize(username: "", password: "", security_token: "", domain: "login", salesforce_version: "42.0", **options)
+      @log = options[:logger] || Logger.new(options[:log_output])
+      @log.progname = "salesforce_chunker"
 
       response = HTTParty.post(
         "https://#{domain}.salesforce.com/services/Soap/u/#{salesforce_version}",
@@ -30,11 +32,13 @@ module SalesforceChunker
     end
 
     def post(url, body, headers={})
+      @log.info "POST: #{url}"
       response = HTTParty.post(@base_url + url, headers: @default_headers.merge(headers), body: body)
       self.class.check_response_error(response.parsed_response)
     end
 
     def get_json(url, headers={})
+      @log.info "GET: #{url}"
       response = HTTParty.get(@base_url + url, headers: @default_headers.merge(headers))
       self.class.check_response_error(response.parsed_response)
     end

--- a/test/lib/connection_test.rb
+++ b/test/lib/connection_test.rb
@@ -6,6 +6,7 @@ class ConnectionTest < Minitest::Test
   def setup
     HTTParty.stubs(:post).returns(login_response)
     @connection = SalesforceChunker::Connection.new({})
+    @connection.instance_variable_set(:@log, Logger.new(nil))
     HTTParty.unstub(:post)
   end
 


### PR DESCRIPTION
This allows logging to be setup on the connection class, as well as the job class.

This will output the url of any url with GET or POST. 

The log info can be passed to the client and then will be sent to the connection, and will be the default for `query`.

- [x] unit tests pass
- [x] manually tested
