### PR TITLE
ManualChunkingQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# CHANGELOG
+
+## 1.1.0 - 2018-11-06
+
+  - Added ManualChunkingQuery, which implements chunking within the gem for any Salesforce field.
+
+## 1.0.0 - 2018-09-12
+
+  - Initial Open Source Release

--- a/lib/salesforce_chunker.rb
+++ b/lib/salesforce_chunker.rb
@@ -3,6 +3,7 @@ require "salesforce_chunker/exceptions.rb"
 require "salesforce_chunker/job.rb"
 require "salesforce_chunker/single_batch_job.rb"
 require "salesforce_chunker/primary_key_chunking_query.rb"
+require "salesforce_chunker/manual_chunking_query.rb"
 require 'logger'
 
 module SalesforceChunker

--- a/lib/salesforce_chunker.rb
+++ b/lib/salesforce_chunker.rb
@@ -22,6 +22,8 @@ module SalesforceChunker
       case options[:job_type]
       when "single_batch"
         job_class = SalesforceChunker::SingleBatchJob
+      when "manual_chunking"
+        job_class = SalesforceChunker::ManualChunkingQuery
       when "primary_key_chunking", nil # for backwards compatibility
         job_class = SalesforceChunker::PrimaryKeyChunkingQuery
       end
@@ -45,6 +47,10 @@ module SalesforceChunker
 
     def primary_key_chunking_query(**options)
       query(**options.merge(job_type: "primary_key_chunking"))
+    end
+
+    def manual_chunking_query(**options)
+      query(**options.merge(job_type: "manual_chunking"))
     end
   end
 end

--- a/lib/salesforce_chunker/manual_chunking_query.rb
+++ b/lib/salesforce_chunker/manual_chunking_query.rb
@@ -1,0 +1,54 @@
+module SalesforceChunker
+  class ManualChunkingQuery < Job
+
+    def initialize(connection:, object:, operation:, query:, **options)
+      batch_size = options[:batch_size] || 100000
+      where_clause = self.class.query_where_clause(query)
+
+      super(connection: connection, object: object, operation: operation, **options)
+      @log.info "Using Manual Chunking"
+
+      @log.info "Retrieving Ids from records"
+      breakpoints = breakpoints(object, where_clause, batch_size)
+
+      @log.info "Creating Query Batches"
+      create_batches(query, breakpoints, where_clause)
+
+      close
+    end
+
+    def get_batch_statuses
+      batches = super
+      batches.delete_if { |batch| batch["id"] == @initial_batch_id && batches.count > 1 }
+    end
+
+    def breakpoints(object, where_clause, batch_size)
+      @batches_count = 1
+      @initial_batch_id = create_batch("Select Id From #{object} #{where_clause} Order By Id Asc")
+
+      download_results(retry_seconds: 10)
+        .with_index
+        .select { |_, i| i % batch_size == 0 && i != 0 }
+        .map { |result, _| result["Id"] }
+    end
+
+    def create_batches(query, breakpoints, where_clause)
+      if breakpoints.empty?
+        create_batch(query)
+      else
+        query += where_clause.empty? ? " Where" : " And"
+
+        create_batch("#{query} Id < '#{breakpoints.first}'")
+        breakpoints.each_cons(2) do |first, second|
+          create_batch("#{query} Id >= '#{first}' And Id < '#{second}'")
+        end
+        create_batch("#{query} Id >= '#{breakpoints.last}'")
+      end
+      @batches_count = breakpoints.length + 1
+    end
+
+    def self.query_where_clause(query)
+      query.partition(/where\s/i)[1..2].join
+    end
+  end
+end

--- a/lib/salesforce_chunker/version.rb
+++ b/lib/salesforce_chunker/version.rb
@@ -1,3 +1,3 @@
 module SalesforceChunker
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/test/lib/manual_chunking_query_test.rb
+++ b/test/lib/manual_chunking_query_test.rb
@@ -1,0 +1,192 @@
+require "test_helper"
+
+class ManualChunkingQueryTest < Minitest::Test
+
+  def setup
+    SalesforceChunker::ManualChunkingQuery.any_instance.stubs(:create_job)
+    SalesforceChunker::ManualChunkingQuery.any_instance.stubs(:breakpoints)
+    SalesforceChunker::ManualChunkingQuery.any_instance.stubs(:create_batches)
+    SalesforceChunker::ManualChunkingQuery.any_instance.stubs(:close)
+    @job = SalesforceChunker::ManualChunkingQuery.new(connection: nil, object: nil, operation: "query", query: "")
+    SalesforceChunker::ManualChunkingQuery.any_instance.unstub(:create_job)
+    SalesforceChunker::ManualChunkingQuery.any_instance.unstub(:breakpoints)
+    SalesforceChunker::ManualChunkingQuery.any_instance.unstub(:create_batches)
+    SalesforceChunker::ManualChunkingQuery.any_instance.unstub(:close)
+    @job.instance_variable_set(:@job_id, "3811P00000EFQiYQAX")
+  end
+
+  def test_get_batch_statuses_returns_only_initial_batch
+    initial_batch = {"id"=> "55024000002iETSAA2", "state"=> "Completed"}
+
+    connection = mock()
+    connection.expects(:get_json).with(
+      "job/3811P00000EFQiYQAX/batch",
+    ).returns({"batchInfo" => [
+      initial_batch,
+    ]})
+
+    @job.instance_variable_set(:@connection, connection)
+    @job.instance_variable_set(:@initial_batch_id, "55024000002iETSAA2")
+
+    assert_equal [initial_batch], @job.get_batch_statuses
+  end
+
+  def test_get_batch_statuses_skips_initial_batch_when_others_created
+    initial_batch = {"id"=> "55024000002iETSAA2", "state"=> "Completed"}
+    another_batch = {"id"=> "55024000002iETTAA2", "state"=> "InProgress"}
+
+    connection = mock()
+    connection.expects(:get_json).with(
+      "job/3811P00000EFQiYQAX/batch",
+    ).returns({"batchInfo" => [
+      initial_batch,
+      another_batch,
+    ]})
+
+    @job.instance_variable_set(:@connection, connection)
+    @job.instance_variable_set(:@initial_batch_id, "55024000002iETSAA2")
+
+    assert_equal [another_batch], @job.get_batch_statuses
+  end
+
+  def test_breakpoints_creates_batch_correctly_and_sets_batches_count
+    @job.expects(:create_batch).with(
+      "Select Id From CustomObject82__c Where SystemModStamp >= 2018-09-15T10:00:00Z Order By Id Asc"
+    )
+    @job.stubs(:download_results).returns([].to_enum)
+
+
+    @job.breakpoints("CustomObject82__c", "Where SystemModStamp >= 2018-09-15T10:00:00Z", 3)
+
+    assert_equal 1, @job.instance_variable_get(:@batches_count)
+  end
+
+  def test_breakpoints_empty_if_smaller_than_batch_size
+    @job.stubs(:create_batch)
+    @job.stubs(:download_results).returns([
+      {"Id" => "id0"},
+      {"Id" => "id1"},
+    ].to_enum)
+
+    assert_empty @job.breakpoints("", "", 3)
+  end
+
+  def test_breakpoints_empty_if_equal_to_batch_size
+    @job.stubs(:create_batch)
+    @job.stubs(:download_results).returns([
+      {"Id" => "id0"},
+      {"Id" => "id1"},
+      {"Id" => "id2"},
+    ].to_enum)
+
+    assert_empty @job.breakpoints("", "", 3)
+  end
+
+  def test_breakpoints_returns_one_point
+    @job.stubs(:create_batch)
+    @job.stubs(:download_results).returns([
+      {"Id" => "id0"},
+      {"Id" => "id1"},
+      {"Id" => "id2"},
+      {"Id" => "id3"},
+    ].to_enum)
+
+    assert_equal ["id3"], @job.breakpoints("", "", 3)
+  end
+
+  def test_breakpoints_returns_multiple_points
+    @job.stubs(:create_batch)
+    @job.stubs(:download_results).returns([
+      {"Id" => "id0"},
+      {"Id" => "id1"},
+      {"Id" => "id2"},
+      {"Id" => "id3"},
+      {"Id" => "id4"},
+      {"Id" => "id5"},
+      {"Id" => "id6"},
+      {"Id" => "id7"},
+    ].to_enum)
+
+    assert_equal ["id3", "id6"], @job.breakpoints("", "", 3)
+  end
+
+  def test_where_clause_exists
+    query = "Select Id From CustomObject26__c Where SystemModStamp >= 2018-08-08T00:02:00Z"
+    where_clause = "Where SystemModStamp >= 2018-08-08T00:02:00Z"
+    assert_equal where_clause, SalesforceChunker::ManualChunkingQuery.query_where_clause(query)
+  end
+
+  def test_where_clause_empty
+    query = "Select Id From CustomObject63__c"
+    assert_empty SalesforceChunker::ManualChunkingQuery.query_where_clause(query)
+  end
+
+  def test_create_batches_with_empty_breakpoints
+    @job.expects(:create_batch).with("Select Id, Name From CustomObject19__c")
+    @job.create_batches("Select Id, Name From CustomObject19__c", [], "")
+    assert_equal 1, @job.instance_variable_get(:@batches_count)
+  end
+
+  def test_create_batches_with_one_breakpoint
+    @job.expects(:create_batch).with("Select Id, Name From CustomObject95__c Where Id < 'id55'").once
+    @job.expects(:create_batch).with("Select Id, Name From CustomObject95__c Where Id >= 'id55'").once
+
+    @job.create_batches("Select Id, Name From CustomObject95__c", ["id55"], "")
+
+    assert_equal 2, @job.instance_variable_get(:@batches_count)
+  end
+
+  def test_create_batches_with_multiple_breakpoints
+    @job.expects(:create_batch).with("Select Id, Name From CustomObject43__c Where Id < 'id23'").once
+    @job.expects(:create_batch).with("Select Id, Name From CustomObject43__c Where Id >= 'id23' And Id < 'id59'").once
+    @job.expects(:create_batch).with("Select Id, Name From CustomObject43__c Where Id >= 'id59' And Id < 'id83'").once
+    @job.expects(:create_batch).with("Select Id, Name From CustomObject43__c Where Id >= 'id83'").once
+
+    @job.create_batches("Select Id, Name From CustomObject43__c", ["id23", "id59", "id83"], "")
+
+    assert_equal 4, @job.instance_variable_get(:@batches_count)
+  end
+
+  def test_create_batches_with_multiple_breakpoints_and_where_clause
+    query = "Select Id, Name From CustomObject43__c Where SystemModStamp >= 2018-09-11T00:00:00Z"
+    where_clause = "Where SystemModStamp >= 2018-09-11T00:00:00Z"
+
+    @job.expects(:create_batch).with("Select Id, Name From CustomObject43__c Where SystemModStamp >= 2018-09-11T00:00:00Z And Id < 'id23'").once
+    @job.expects(:create_batch).with("Select Id, Name From CustomObject43__c Where SystemModStamp >= 2018-09-11T00:00:00Z And Id >= 'id23' And Id < 'id59'").once
+    @job.expects(:create_batch).with("Select Id, Name From CustomObject43__c Where SystemModStamp >= 2018-09-11T00:00:00Z And Id >= 'id59' And Id < 'id83'").once
+    @job.expects(:create_batch).with("Select Id, Name From CustomObject43__c Where SystemModStamp >= 2018-09-11T00:00:00Z And Id >= 'id83'").once
+
+    @job.create_batches(query, ["id23", "id59", "id83"], where_clause)
+  end
+
+
+  def test_initialize_creates_job_and_batches
+    SalesforceChunker::Job.any_instance.expects(:create_job)
+      .with("CustomObject__c", {})
+      .returns("3811P00000EFQiYQAZ")
+
+    SalesforceChunker::ManualChunkingQuery.any_instance.expects(:breakpoints)
+      .with("CustomObject__c", "Where SystemModStamp >= 2018-09-12T00:00:00Z", 8600)
+      .returns(["id_123"])
+
+    SalesforceChunker::ManualChunkingQuery.any_instance.expects(:create_batches).with(
+      "Select CustomColumn__c From CustomObject__c Where SystemModStamp >= 2018-09-12T00:00:00Z",
+      ["id_123"],
+      "Where SystemModStamp >= 2018-09-12T00:00:00Z",
+    )
+
+    SalesforceChunker::ManualChunkingQuery.any_instance.expects(:close)
+
+    job = SalesforceChunker::ManualChunkingQuery.new(
+      connection: "connect",
+      object: "CustomObject__c",
+      operation: "query",
+      query: "Select CustomColumn__c From CustomObject__c Where SystemModStamp >= 2018-09-12T00:00:00Z",
+      batch_size: 8600,
+    )
+
+    assert_equal "connect", job.instance_variable_get(:@connection)
+    assert_equal "query", job.instance_variable_get(:@operation)
+    assert_equal "3811P00000EFQiYQAZ", job.instance_variable_get(:@job_id)
+  end
+end

--- a/test/salesforce_chunker_test.rb
+++ b/test/salesforce_chunker_test.rb
@@ -45,6 +45,17 @@ class SalesforceChunkerTest < Minitest::Test
     assert_equal [{"CustomColumn__c" => "abc"}], actual_results
   end
 
+  def test_query_with_job_type_manual_chunking
+    job = mock()
+    job.expects(:download_results).yields({"CustomColumn__c" => "abc"})
+    SalesforceChunker::ManualChunkingQuery.stubs(:new).returns(job)
+
+    actual_results = []
+    @client.query(query: "", object: "", retry_seconds: 0, job_type: "manual_chunking") { |result| actual_results << result }
+
+    assert_equal [{"CustomColumn__c" => "abc"}], actual_results
+  end
+
   def test_single_batch_query
     @client.expects(:query).with(query: "q", object: "o", job_type: "single_batch")
     @client.single_batch_query(query: "q", object: "o") {}
@@ -53,5 +64,10 @@ class SalesforceChunkerTest < Minitest::Test
   def test_primary_key_chunking_query
     @client.expects(:query).with(query: "q", object: "o", job_type: "primary_key_chunking")
     @client.primary_key_chunking_query(query: "q", object: "o") {}
+  end
+
+  def test_manual_chunking_query
+    @client.expects(:query).with(query: "q", object: "o", job_type: "manual_chunking")
+    @client.manual_chunking_query(query: "q", object: "o") {}
   end
 end


### PR DESCRIPTION
A lot of the motivation and issues behind this is spelled out here: https://github.com/Shopify/salesforce_chunker/issues/50

Since PK Chunking is only available for a handful of fields, this creates a `ManualChunkingQuery` that implements chunking.

- [x] Manually tested, with where clause, downloaded 100k records from object with 10M+ records.
- [x] Manually tested, without where clause - downloaded 7 columns from 10M+ records in ~15 minutes - used `oj` for parsing to speed up and lower memory requirements (not yet in master). About half of this time was waiting for initial query. Also, I did not save any of the records but printed them out with very low probability to ensure real info was being received.
