### PR TITLE
Retrieve raw results 

### DIFF
--- a/lib/salesforce_chunker/connection.rb
+++ b/lib/salesforce_chunker/connection.rb
@@ -43,6 +43,11 @@ module SalesforceChunker
       self.class.check_response_error(response.parsed_response)
     end
 
+    def get(url, headers={})
+      @log.info "GET: #{url}"
+      HTTParty.get(@base_url + url, headers: @default_headers.merge(headers)).body
+    end
+
     private
 
     def self.login_soap_request_body(username, password, security_token)

--- a/lib/salesforce_chunker/job.rb
+++ b/lib/salesforce_chunker/job.rb
@@ -1,3 +1,5 @@
+require "json"
+
 module SalesforceChunker
   class Job
     attr_reader :batches_count
@@ -56,7 +58,13 @@ module SalesforceChunker
 
     def get_batch_results(batch_id)
       retrieve_batch_results(batch_id).each do |result_id|
-        retrieve_results(batch_id, result_id).each do |result|
+        results = retrieve_raw_results(batch_id, result_id)
+
+        @log.info "Parsing JSON response"
+        parsed_results = JSON.parse(results)
+
+        @log.info "Yielding records"
+        parsed_results.each do |result|
           result.tap { |h| h.delete("attributes") }
           yield(result)
         end
@@ -83,6 +91,10 @@ module SalesforceChunker
 
     def retrieve_results(batch_id, result_id)
       @connection.get_json("job/#{@job_id}/batch/#{batch_id}/result/#{result_id}")
+    end
+
+    def retrieve_raw_results(batch_id, result_id)
+      @connection.get("job/#{@job_id}/batch/#{batch_id}/result/#{result_id}")
     end
 
     def close

--- a/test/lib/connection_test.rb
+++ b/test/lib/connection_test.rb
@@ -43,7 +43,8 @@ class ConnectionTest < Minitest::Test
     HTTParty.expects(:post).with(expected_url, body: "blah", headers: expected_headers).returns(json_response)
 
     response = @connection.post("route", "blah")
-    assert_equal 1234, response
+    expected = {"a" => 2}
+    assert_equal expected, response
   end
 
   def test_get_json_calls_get_with_correct_parameters
@@ -56,7 +57,21 @@ class ConnectionTest < Minitest::Test
     HTTParty.expects(:get).with(expected_url, headers: expected_headers).returns(json_response)
 
     response = @connection.get_json("getroute")
-    assert_equal 1234, response
+    expected = {"a" => 2}
+    assert_equal expected, response
+  end
+
+  def test_get_returns_response_object
+    expected_url = "https://na99.salesforce.com/services/async/42.0/getroute"
+    expected_headers = {
+      "Content-Type": "application/json",
+      "X-SFDC-Session": "3ea96c71f254c3f2e6ce3a2b2b723c87",
+      "Accept-Encoding": "gzip",
+    }
+    HTTParty.expects(:get).with(expected_url, headers: expected_headers).returns(json_response)
+
+    response = @connection.get("getroute")
+    assert_equal "{\"a\":2}", response
   end
 
   def test_headers_can_be_overridden
@@ -136,8 +151,6 @@ class ConnectionTest < Minitest::Test
   end
 
   def json_response
-    parsed_response = mock()
-    parsed_response.stubs(:parsed_response).returns(1234)
-    parsed_response
+    stub(parsed_response: {"a" => 2}, body: "{\"a\":2}")
   end
 end

--- a/test/lib/job_test.rb
+++ b/test/lib/job_test.rb
@@ -44,14 +44,12 @@ class JobTest < Minitest::Test
       "6502E000002iETSAA3",
       "6502E000002jETSAA3",
     ])
-    @job.expects(:retrieve_results).with("55024000002iETSAA2", "6502E000002iETSAA3").returns([
-      {"CustomColumn__c" => "abc", "attributes" => "blah"},
-      {"CustomColumn__c" => "def", "attributes" => "blah"},
-    ])
-    @job.expects(:retrieve_results).with("55024000002iETSAA2", "6502E000002jETSAA3").returns([
-      {"CustomColumn__c" => "ghi", "attributes" => "blah"},
-      {"CustomColumn__c" => "jkl", "attributes" => "blah"},
-    ])
+    @job.expects(:retrieve_raw_results).with("55024000002iETSAA2", "6502E000002iETSAA3").returns(
+      "[{\"CustomColumn__c\":\"abc\",\"attributes\":\"blah\"},{\"CustomColumn__c\":\"def\",\"attributes\":\"blah\"}]"
+    )
+    @job.expects(:retrieve_raw_results).with("55024000002iETSAA2", "6502E000002jETSAA3").returns(
+      "[{\"CustomColumn__c\":\"ghi\",\"attributes\":\"blah\"},{\"CustomColumn__c\":\"jkl\",\"attributes\":\"blah\"}]"
+    )
 
     actual_results = []
     @job.get_batch_results("55024000002iETSAA2") { |result| actual_results.append(result) }
@@ -146,6 +144,18 @@ class JobTest < Minitest::Test
     @job.instance_variable_set(:@connection, connection)
 
     assert_equal [{CustomColumn__c: "abc"}], @job.retrieve_results("55024000002iETSAA2", "6502E000002iETSAA3")
+  end
+
+  def test_retrieve_raw_results_returns_information
+    connection = mock()
+    connection.expects(:get).with(
+      "job/3811P00000EFQiYQAX/batch/55024000002iETSAA2/result/6502E000002iETSAA3",
+    ).returns(
+      "[{\"CustomColumn__c\":\"abc\"}]",
+    )
+    @job.instance_variable_set(:@connection, connection)
+
+    assert_equal "[{\"CustomColumn__c\":\"abc\"}]", @job.retrieve_raw_results("55024000002iETSAA2", "6502E000002iETSAA3")
   end
 
   def test_close_posts_json


### PR DESCRIPTION
This PR does 2 things:
- creates a `get` function that returns the response body as a string (not parsed)
- Uses this function in `retrieve_raw_results` and `get_batch_results`


There are several reasons for doing this:
- we're looking into JSON streaming parsing (`oj`), instead of JSON.parse
- the ManualChunkingQuery can parse CSV better with IDs by overriding the `get_batch_results` function.
- this allows us to have better logging to see what is taking the most time

Testing
- [x] unit tests pass
- [x] manually tested

