### PR TITLE
allow custom contentType in job

### DIFF
--- a/lib/salesforce_chunker/job.rb
+++ b/lib/salesforce_chunker/job.rb
@@ -96,7 +96,7 @@ module SalesforceChunker
       body = {
         "operation": @operation,
         "object": object,
-        "contentType": "JSON",
+        "contentType": options[:content_type] || "JSON",
       }
       body[:externalIdFieldName] = options[:external_id] if @operation == "upsert"
       @connection.post_json("job", body, options[:headers].to_h)["id"]

--- a/test/lib/job_test.rb
+++ b/test/lib/job_test.rb
@@ -95,6 +95,21 @@ class JobTest < Minitest::Test
     @job.send(:create_job, "CustomObject__c", {"external_id": "Field__c"})
   end
 
+  def test_create_job_allows_different_content_type
+    connection = mock()
+    connection.expects(:post_json).with(
+      "job",
+      {"operation": "query", "object": "CustomObject__c", "contentType": "CSV"},
+      {},
+    ).returns({
+      "id" => "3811P00000EFQiYQAX"
+    })
+    @job.instance_variable_set(:@connection, connection)
+    @job.instance_variable_set(:@operation, "query")
+
+    @job.send(:create_job, "CustomObject__c", {"content_type": "CSV"})
+  end
+
   def test_create_batch_sends_query_as_string
     connection = mock()
     connection.expects(:post).with(


### PR DESCRIPTION
This allows it to be set to "CSV" or "XML", the other options.

It isn't being exposed to the public at this point, because the other functions will break. This is necessary for CSV handling of Ids in Manual Chunking.

- [x] unit tests
- [x] manually tested