### PR TITLE
update ManualChunkingQuery to use ManualChunkingBreakpointQuery

### DIFF
--- a/lib/salesforce_chunker/manual_chunking_query.rb
+++ b/lib/salesforce_chunker/manual_chunking_query.rb
@@ -2,34 +2,28 @@ module SalesforceChunker
   class ManualChunkingQuery < Job
 
     def initialize(connection:, object:, operation:, query:, **options)
+      @log = options.delete(:logger) || Logger.new(options[:log_output])
+      @log.progname = "salesforce_chunker"
       batch_size = options[:batch_size] || 100000
       where_clause = self.class.query_where_clause(query)
 
-      super(connection: connection, object: object, operation: operation, **options)
       @log.info "Using Manual Chunking"
+      breakpoint_creation_job = SalesforceChunker::ManualChunkingBreakpointQuery.new(
+        connection: connection,
+        object: object,
+        operation: operation,
+        logger: @log,
+        batch_size: batch_size,
+        query: "Select Id From #{object} #{where_clause} Order By Id Asc",
+      )
+      breakpoints = breakpoint_creation_job.download_results(retry_seconds: 10).to_a
 
-      @log.info "Retrieving Ids from records"
-      breakpoints = breakpoints(object, where_clause, batch_size)
+      super(connection: connection, object: object, operation: operation, logger: @log, **options)
 
       @log.info "Creating Query Batches"
       create_batches(query, breakpoints, where_clause)
 
       close
-    end
-
-    def get_batch_statuses
-      batches = super
-      batches.delete_if { |batch| batch["id"] == @initial_batch_id && batches.count > 1 }
-    end
-
-    def breakpoints(object, where_clause, batch_size)
-      @batches_count = 1
-      @initial_batch_id = create_batch("Select Id From #{object} #{where_clause} Order By Id Asc")
-
-      download_results(retry_seconds: 10)
-        .with_index
-        .select { |_, i| i % batch_size == 0 && i != 0 }
-        .map { |result, _| result["Id"] }
     end
 
     def create_batches(query, breakpoints, where_clause)


### PR DESCRIPTION
This is the second PR following https://github.com/Shopify/salesforce_chunker/pull/56 that deals with getting the initial Id batch with CSV instead of JSON.

It now needs to create a new `Job`, because it is a different content-type. 

- [x] unit tests
- [x] tested manually