### PR TITLE
Only sleep if no new results downloaded

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,4 +33,4 @@ DEPENDENCIES
   salesforce_chunker!
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/lib/salesforce_chunker/job.rb
+++ b/lib/salesforce_chunker/job.rb
@@ -29,20 +29,27 @@ module SalesforceChunker
       downloaded_batches = []
 
       loop do
+        no_results_downloaded = true
         @log.info "Retrieving batch status information"
         get_completed_batches.each do |batch|
           next if downloaded_batches.include?(batch["id"])
           @log.info "Batch #{downloaded_batches.length + 1} of #{@batches_count || '?'}: " \
             "retrieving #{batch["numberRecordsProcessed"]} records"
-          get_batch_results(batch["id"]) { |result| yield(result) } if batch["numberRecordsProcessed"].to_i > 0
+          if batch["numberRecordsProcessed"].to_i > 0
+            get_batch_results(batch["id"]) { |result| yield(result) }
+            no_results_downloaded = false
+          end
           downloaded_batches.append(batch["id"])
         end
 
         break if @batches_count && downloaded_batches.length == @batches_count
-        raise TimeoutError, "Timeout during batch processing" if Time.now.utc > timeout_at
 
-        @log.info "Waiting #{retry_seconds} seconds"
-        sleep(retry_seconds)
+        if no_results_downloaded
+          raise TimeoutError, "Timeout during batch processing" if Time.now.utc > timeout_at
+
+          @log.info "Waiting #{retry_seconds} seconds"
+          sleep(retry_seconds)
+        end
       end
       
       @log.info "Completed"

--- a/test/lib/job_test.rb
+++ b/test/lib/job_test.rb
@@ -237,12 +237,12 @@ class JobTest < Minitest::Test
       {"id" => "55024000002iETUAA2", "state" => "Completed", "numberRecordsFailed" => 0, "numberRecordsProcessed" => 3},
     ]
 
-    second_completed_batches = [
+    final_completed_batches = [
       {"id" => "55024000002iETTAA2", "state" => "Completed", "numberRecordsFailed" => 0, "numberRecordsProcessed" => 1},
       {"id" => "55024000002iETUAA2", "state" => "Completed", "numberRecordsFailed" => 0, "numberRecordsProcessed" => 3},
     ]
 
-    @job.expects(:get_completed_batches).twice.returns(first_completed_batches, second_completed_batches)
+    @job.expects(:get_completed_batches).times(3).returns(first_completed_batches, first_completed_batches, final_completed_batches)
 
     @job.expects(:get_batch_results).with("55024000002iETUAA2").multiple_yields(
       [{"CustomColumn__c" => "abc"}],


### PR DESCRIPTION
This PR changes the `download_results` loop to only sleep for `retry_seconds` if no records are downloaded in the loop.

What ends up happening is that half of the batches finish, the program takes a minute or so to download them, and then the program sleeps for a number of seconds even though other batches are probably ready to download.

If the batches are really small, then this could create a situation where we get the batch statuses a second or so later. Worst case, this would waste an API call every once in a while. However, with manual_chunking and a decent batch size, this would rarely happen.

Also, this makes the `TimeoutError` safer because it wont risk throwing an error if we are in the middle of downloading a ton of data. If a batch doesn't finish after an hour, something is probably wrong.