### PR TITLE
Support queryAll operation for including deleted records

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ options = {
   logger:           nil,
   log_output:       STDOUT,
   job_type:         "primary_key_chunking",
+  include_deleted:  true,
 }
 
 client.query(options) do |result|
@@ -93,6 +94,7 @@ end
 | logger | optional | logger to use. Must be instance of or similar to rails logger. |
 | log_output | optional | log output to use. i.e. `STDOUT`. |
 | job_type | optional | defaults to `"primary_key_chunking"`. Can also be set to `"single_batch"`. |
+| include_deleted | optional | defaults to `false`. Whether to include deleted records. |
 
 `query` can either be called with a block, or will return an enumerator:
 

--- a/lib/salesforce_chunker.rb
+++ b/lib/salesforce_chunker.rb
@@ -29,10 +29,12 @@ module SalesforceChunker
         job_class = SalesforceChunker::PrimaryKeyChunkingQuery
       end
 
+      operation = options[:include_deleted] ? "queryAll" : "query"
+
       job_params = {
         connection: @connection,
         object: object,
-        operation: "query",
+        operation: operation,
         query: query,
         **options.slice(:batch_size, :logger, :log_output)
       }

--- a/lib/salesforce_chunker/job.rb
+++ b/lib/salesforce_chunker/job.rb
@@ -4,7 +4,7 @@ module SalesforceChunker
   class Job
     attr_reader :batches_count
 
-    QUERY_OPERATIONS = ["query", "queryall"].freeze
+    QUERY_OPERATIONS = ["query", "queryAll"].freeze
     DEFAULT_RETRY_SECONDS = 10
     DEFAULT_TIMEOUT_SECONDS = 3600
 

--- a/test/salesforce_chunker_test.rb
+++ b/test/salesforce_chunker_test.rb
@@ -34,6 +34,17 @@ class SalesforceChunkerTest < Minitest::Test
     assert_equal [{"CustomColumn__c" => "abc"}], actual_results.to_a
   end
 
+  def test_query_include_deleted
+    job = mock()
+    job.expects(:download_results).yields({"CustomColumn__c" => "abc"})
+    SalesforceChunker::PrimaryKeyChunkingQuery.stubs(:new).with(has_entry(operation: "queryAll")).returns(job)
+
+    actual_results = []
+    @client.query(query: "", object: "", retry_seconds: 0, include_deleted: true) { |result| actual_results << result }
+
+    assert_equal [{"CustomColumn__c" => "abc"}], actual_results
+  end
+
   def test_query_with_job_type_single_batch
     job = mock()
     job.expects(:download_results).yields({"CustomColumn__c" => "abc"})


### PR DESCRIPTION
There's currently no way for callers to tell `salesforce_chunker` to include deleted records, which are only included if the `operation` invoked is `queryAll` instead of `query`.

This PR adds a new parameter called `include_deleted` to the `query` method, which if set to `true` sets the operation to `queryAll`.