### PR TITLE
disable explicit gzip

### DIFF
--- a/lib/salesforce_chunker/connection.rb
+++ b/lib/salesforce_chunker/connection.rb
@@ -21,7 +21,6 @@ module SalesforceChunker
       @default_headers = {
         "Content-Type": "application/json",
         "X-SFDC-Session": result["sessionId"],
-        "Accept-Encoding": "gzip",
       }
     rescue NoMethodError
       raise ConnectionError, response["Envelope"]["Body"]["Fault"]["faultstring"]

--- a/test/lib/connection_test.rb
+++ b/test/lib/connection_test.rb
@@ -38,7 +38,6 @@ class ConnectionTest < Minitest::Test
     expected_headers = {
       "Content-Type": "application/json",
       "X-SFDC-Session": "3ea96c71f254c3f2e6ce3a2b2b723c87",
-      "Accept-Encoding": "gzip",
     }
     HTTParty.expects(:post).with(expected_url, body: "blah", headers: expected_headers).returns(json_response)
 
@@ -52,7 +51,6 @@ class ConnectionTest < Minitest::Test
     expected_headers = {
       "Content-Type": "application/json",
       "X-SFDC-Session": "3ea96c71f254c3f2e6ce3a2b2b723c87",
-      "Accept-Encoding": "gzip",
     }
     HTTParty.expects(:get).with(expected_url, headers: expected_headers).returns(json_response)
 
@@ -66,7 +64,6 @@ class ConnectionTest < Minitest::Test
     expected_headers = {
       "Content-Type": "application/json",
       "X-SFDC-Session": "3ea96c71f254c3f2e6ce3a2b2b723c87",
-      "Accept-Encoding": "gzip",
     }
     HTTParty.expects(:get).with(expected_url, headers: expected_headers).returns(json_response)
 
@@ -79,7 +76,6 @@ class ConnectionTest < Minitest::Test
     expected_headers = {
       "Content-Type": "text/csv",
       "X-SFDC-Session": "3ea96c71f254c3f2e6ce3a2b2b723c87",
-      "Accept-Encoding": "gzip",
       "Foo": "bar",
     }
     HTTParty.expects(:get).with(expected_url, headers: expected_headers).returns(json_response)


### PR DESCRIPTION
Ruby net::http automatically adds gzip encoding headers; if they're set explicitly responses will have to be inflated manually (https://github.com/jnunemaker/httparty/issues/562). 