### PR TITLE
update min version of httparty to 0.15

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,20 @@ PATH
   remote: .
   specs:
     salesforce_chunker (1.1.1)
-      httparty (~> 0.13)
+      httparty (~> 0.15)
 
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.2)
-    httparty (0.16.3)
+    httparty (0.17.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     metaclass (0.0.4)
     method_source (0.9.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2019.0331)
     minitest (5.11.3)
     mocha (1.5.0)
       metaclass (~> 0.0.1)
@@ -37,4 +37,4 @@ DEPENDENCIES
   salesforce_chunker!
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/salesforce_chunker.gemspec
+++ b/salesforce_chunker.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "httparty", "~> 0.13"
+  spec.add_dependency "httparty", "~> 0.15"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
HTTParty changed its decompression logic in 0.15 (https://github.com/jnunemaker/httparty/pull/513/commits/6f6bf6b726484eaf50e190769bbe14c9841a2c64#diff-580cbdf9b30c3492eaffdfa72a97aa58R189)

We had to remove the explicit gzip handling in this PR: https://github.com/Shopify/salesforce_chunker/pull/61

To ensure that the compression continues to work properly in the next version of the gem, we should set a minimum dependency of HTTParty `0.15`