### PR TITLE
Update version to 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ sudo: false
 language: ruby
 rvm:
   - 2.5.0
-before_install: gem install bundler -v 1.17.1
+before_install: gem install bundler -v 1.17.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.2.0 - 2019-06-14
+
+  - Added an include_deleted flag to perform a queryAll operation.
+  - Disabled explicit GZIP encoding to work with the latest versions of HTTParty.
+  - Added a retry for requests to recover from Net::ReadTimeout errors
+
 ## 1.1.1 - 2018-11-26
 
   - Reimplemented ManualChunkingQuery using CSV batch results.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,20 @@ PATH
   remote: .
   specs:
     salesforce_chunker (1.1.1)
-      httparty (~> 0.13)
+      httparty (~> 0.15)
 
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.2)
-    httparty (0.16.3)
+    httparty (0.17.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     metaclass (0.0.4)
     method_source (0.9.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2019.0331)
     minitest (5.11.3)
     mocha (1.5.0)
       metaclass (~> 0.0.1)
@@ -37,4 +37,4 @@ DEPENDENCIES
   salesforce_chunker!
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    salesforce_chunker (1.1.1)
+    salesforce_chunker (1.2.0)
       httparty (~> 0.15)
 
 GEM

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 Shopify
+Copyright (c) 2018-2019 Shopify
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/salesforce_chunker/version.rb
+++ b/lib/salesforce_chunker/version.rb
@@ -1,3 +1,3 @@
 module SalesforceChunker
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 end

--- a/salesforce_chunker.gemspec
+++ b/salesforce_chunker.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "httparty", "~> 0.13"
+  spec.add_dependency "httparty", "~> 0.15"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Going ahead and cutting a new version of the gem now. 

HTTParty changed its decompression logic in 0.15 (https://github.com/jnunemaker/httparty/pull/513/commits/6f6bf6b726484eaf50e190769bbe14c9841a2c64#diff-580cbdf9b30c3492eaffdfa72a97aa58R189)

We had to remove the explicit gzip handling in this PR: https://github.com/Shopify/salesforce_chunker/pull/61

To ensure that the compression continues to work properly in the next version of the gem, we should set a minimum dependency of HTTParty `0.15`