### PR TITLE
remove circular log argument

### DIFF
--- a/lib/salesforce_chunker/connection.rb
+++ b/lib/salesforce_chunker/connection.rb
@@ -86,7 +86,7 @@ module SalesforceChunker
     MAX_TRIES = 5
     SLEEP_DURATION = 10
 
-    def self.retry_block(log: log, tries: MAX_TRIES, sleep_duration: SLEEP_DURATION, rescues:, &block)
+    def self.retry_block(log: Logger.new(nil), tries: MAX_TRIES, sleep_duration: SLEEP_DURATION, rescues:, &block)
       attempt_number = 1
 
       begin


### PR DESCRIPTION
getting a warning message when using this gem: `/Users/curtisholmes/src/github.com/Shopify/salesforce_chunker/lib/salesforce_chunker/connection.rb:89: warning: circular argument reference - log`

In line 89, `log` isn't defined. Sets new logger to nil if it isn't set.

- [x] tests pass
