### PR TITLE
add IOError to retry block

### DIFF
--- a/lib/salesforce_chunker/connection.rb
+++ b/lib/salesforce_chunker/connection.rb
@@ -32,7 +32,7 @@ module SalesforceChunker
 
     def post(url, body, headers={})
       @log.info "POST: #{url}"
-      response = self.class.retry_block(log: @log, rescues: Net::ReadTimeout) do
+      response = self.class.retry_block(log: @log) do
         HTTParty.post(@base_url + url, headers: @default_headers.merge(headers), body: body)
       end
       self.class.check_response_error(response.parsed_response)
@@ -40,7 +40,7 @@ module SalesforceChunker
 
     def get_json(url, headers={})
       @log.info "GET: #{url}"
-      response = self.class.retry_block(log: @log, rescues: Net::ReadTimeout) do
+      response = self.class.retry_block(log: @log) do
         HTTParty.get(@base_url + url, headers: @default_headers.merge(headers))
       end
       self.class.check_response_error(response.parsed_response)
@@ -48,7 +48,7 @@ module SalesforceChunker
 
     def get(url, headers={})
       @log.info "GET: #{url}"
-      self.class.retry_block(log: @log, rescues: Net::ReadTimeout) do
+      self.class.retry_block(log: @log) do
         HTTParty.get(@base_url + url, headers: @default_headers.merge(headers)).body
       end
     end
@@ -85,8 +85,9 @@ module SalesforceChunker
 
     MAX_TRIES = 5
     SLEEP_DURATION = 10
+    RESCUED_EXCEPTIONS = [Net::ReadTimeout, IOError]
 
-    def self.retry_block(log: Logger.new(nil), tries: MAX_TRIES, sleep_duration: SLEEP_DURATION, rescues:, &block)
+    def self.retry_block(log: Logger.new(nil), tries: MAX_TRIES, sleep_duration: SLEEP_DURATION, rescues: RESCUED_EXCEPTIONS, &block)
       attempt_number = 1
 
       begin

--- a/test/lib/connection_test.rb
+++ b/test/lib/connection_test.rb
@@ -77,7 +77,7 @@ class ConnectionTest < Minitest::Test
       "Content-Type": "application/json",
       "X-SFDC-Session": "3ea96c71f254c3f2e6ce3a2b2b723c87",
     }
-    HTTParty.expects(:get).twice.with(expected_url, headers: expected_headers).raises(Net::ReadTimeout).then.returns(json_response)
+    HTTParty.expects(:get).twice.with(expected_url, headers: expected_headers).raises(IOError).then.returns(json_response)
 
     # suppress warning: already initialized constant
     v, $VERBOSE = $VERBOSE, nil


### PR DESCRIPTION
We are seeing `IOError` instances from Salesforce running on Jruby. This attempts to retry them

- [x] tests pass
- [x] was able to manually catch an error and retry it