### PR TITLE
Fix Bug in Manual Chunking batches with multiple result pages

### DIFF
--- a/lib/salesforce_chunker/manual_chunking_breakpoint_query.rb
+++ b/lib/salesforce_chunker/manual_chunking_breakpoint_query.rb
@@ -12,17 +12,19 @@ module SalesforceChunker
     end
 
     def get_batch_results(batch_id)
-      retrieve_batch_results(batch_id).each do |result_id|
+      retrieve_batch_results(batch_id).each_with_index do |result_id, result_index|
         results = retrieve_raw_results(batch_id, result_id)
 
         @log.info "Generating breakpoints from CSV results"
-        process_csv_results(results) { |result| yield result }
+        process_csv_results(results, result_index > 0) { |result| yield result }
       end
     end
 
-    def process_csv_results(result)
-      lines = result.each_line
+    def process_csv_results(input, include_first_element)
+      lines = input.each_line
       headers = lines.next
+
+      yield(lines.peek.chomp.gsub("\"", "")) if include_first_element
 
       loop do
         @batch_size.times { lines.next }


### PR DESCRIPTION
I found a bug in manual chunking which only manifests if there are multiple results pages for the IDs. This happened while trying to extract 20 million rows.

The previous code didn't adjust the breakpoints for the different pages, and it is possible for one of the batches to be up to 2x the batch size.

For example, if the batch size is 10k, and the first result page returns 77k records, and the second result page returns 22k records, there would be a large batch with 17k records (70-77k and 0-10k on the second page).

The first approach I tried to take here was creating a counter and storing an offset, but I think that is a bit more complicated than necessary. I was worried that the counter would slow down the speed of the processing. This will break it up so there are 11 total batches, one is only 7k and the other is only 2k. 

- [x] test pass
- [x] manually tested