### PR TITLE
fix timeout_seconds option name

### DIFF
--- a/lib/salesforce_chunker.rb
+++ b/lib/salesforce_chunker.rb
@@ -41,7 +41,7 @@ module SalesforceChunker
       job_params[:logger] = @log if job_params[:logger].nil? && job_params[:log_output].nil?
 
       job = job_class.new(**job_params)
-      job.download_results(**options.slice(:timeout, :retry_seconds)) { |result| yield(result) }
+      job.download_results(**options.slice(:timeout_seconds, :retry_seconds)) { |result| yield(result) }
     end
 
     def single_batch_query(**options)


### PR DESCRIPTION
`salesforce_chunker` is passing the wrong option name `timeout` to `job.download_results`; it should be `timeout_seconds`.

We tried to override that option in our salesforce extractor job, but it didn't have any effect due to this bug.

Related: https://github.com/Shopify/longboat/pull/8957